### PR TITLE
fix(symbol as default value)

### DIFF
--- a/lib/rspec/virtus/matcher.rb
+++ b/lib/rspec/virtus/matcher.rb
@@ -81,7 +81,7 @@ module RSpec
         when ::Proc
           value.call(@instance, attribute)
         when ::Symbol
-          @instance.__send__(value)
+          @instance.respond_to?(value, true) ? __send__(value) : value
         else
           value
         end


### PR DESCRIPTION
According to https://github.com/solnic/virtus/blob/master/lib/virtus/attribute/default_value/from_symbol.rb#L29, symbols as default values are not necessarily methods to call.
